### PR TITLE
modified logout button action to remove the token (real logout)

### DIFF
--- a/fix_realxstate/lib/providers/auth.dart
+++ b/fix_realxstate/lib/providers/auth.dart
@@ -23,7 +23,13 @@ class Auth with ChangeNotifier {
     return null;
   }
 
-// REST API documentation from: l
+  void deleteToken() {
+    // function that removes token for "logout" button, and notifies listeneer so that main page is recreated (back to auth page)
+    _token = null;
+    notifyListeners();
+  }
+
+// REST API documentation from: https://firebase.google.com/docs/reference/rest/auth
   Future<void> _authenticate(
       String urlPath, String email, String password) async {
     final url = Uri.parse(
@@ -41,6 +47,7 @@ class Auth with ChangeNotifier {
         ),
       );
       final info = jsonDecode(resp.body);
+      // print(info);  //uncomment for debugging
       if (info['error'] != null) {
         return Future.error(HttpException(info['error'][
             'message'])); //TODO: figure out why return needs to be used and not 'throw" for HttpException does not work
@@ -56,7 +63,7 @@ class Auth with ChangeNotifier {
       );
       notifyListeners(); // in order to trigger main page's Consumer
       return info;
-    } on Exception catch (error) {
+    } catch (error) {
       throw error.toString();
     }
   }

--- a/fix_realxstate/lib/screens/landing.dart
+++ b/fix_realxstate/lib/screens/landing.dart
@@ -128,7 +128,8 @@ class LandingPage extends StatelessWidget {
                   leading: Icon(Icons.logout),
                   title: Text("Logout!"),
                   onTap: () {
-                    Navigator.of(context).pushNamed(AuthScreen.routeName);
+                    Provider.of<Auth>(context, listen: false).deleteToken();
+                    // Navigator.of(context).pushNamed(AuthScreen.routeName);
                   }),
             ],
           ),

--- a/fix_realxstate/lib/screens/landing.dart
+++ b/fix_realxstate/lib/screens/landing.dart
@@ -129,7 +129,6 @@ class LandingPage extends StatelessWidget {
                   title: Text("Logout!"),
                   onTap: () {
                     Provider.of<Auth>(context, listen: false).deleteToken();
-                    // Navigator.of(context).pushNamed(AuthScreen.routeName);
                   }),
             ],
           ),


### PR DESCRIPTION
- `landing.dart`:  modified `onTap` of logout button to call `Auth.deleteToken` (inside `providers.auth.dart`)
- `auth.dart`: added debugging print statements + commented them out