### PR TITLE
Authentication for DB access + data retrieval

### DIFF
--- a/fix_realxstate/lib/main.dart
+++ b/fix_realxstate/lib/main.dart
@@ -31,9 +31,19 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
         providers: [
           // ChangeNotifierProvider(create: (ctx) => PropertyList()),
-          ChangeNotifierProvider(create: (ctx) => CashflowList()),
-          ChangeNotifierProvider(create: (ctx) => PropertyList()),
-          ChangeNotifierProvider(create: (ctx) => Auth())
+          ChangeNotifierProvider(
+              create: (ctx) =>
+                  Auth()), // Note: Auth() needs to be provided first, in order to be able to use it in ChangeNotifierproxyProvider
+          ChangeNotifierProxyProvider<Auth, CashflowList>(
+            create: (ctx) => CashflowList(null, []),
+            update: (ctx, auth, previousCashflow) => CashflowList(auth.token,
+                previousCashflow == null ? [] : previousCashflow.entries),
+          ),
+          ChangeNotifierProxyProvider<Auth, PropertyList>(
+            create: (ctx) => PropertyList(null, []),
+            update: (ctx, auth, previousProperties) => PropertyList(auth.token,
+                previousProperties == null ? [] : previousProperties.entries),
+          ), //will be rebuild when auth changes, as auth is now a dependency of the proxy-provider
         ],
         child: Consumer<Auth>(
           builder: (ctx, authData, _) => MaterialApp(

--- a/fix_realxstate/lib/providers/property_list.dart
+++ b/fix_realxstate/lib/providers/property_list.dart
@@ -7,16 +7,21 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import './property_item.dart';
 
 class PropertyList with ChangeNotifier {
-  List<PropertyItem> _entries = [];
+  List<PropertyItem> entries = [];
 
   // var _showFavoritesOnly = false;
 
+  late final String? authToken;
+
+  PropertyList(this.authToken,
+      this.entries); // Properties will be shown in list based on token provided
+
   Future<void> getProps() async {
     // TODO: implement _firstLoad check - in order to not load this every time that page is relaoaded (e.g. due to saving file)
-    _entries =
+    entries =
         []; // reset property list ,as properties will otherwise appear multiple times on screen (multiplied at every re-load)
-    final response = await http
-        .get(Uri.parse("${dotenv.env["FIREBASE_URL"]}properties.json"));
+    final response = await http.get(Uri.parse(
+        "${dotenv.env["FIREBASE_URL"]}properties.json?auth=$authToken"));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(
@@ -43,7 +48,7 @@ class PropertyList with ChangeNotifier {
                 ? propdata['brokeEven']
                 : false,
           );
-          _entries.add(currentProp);
+          entries.add(currentProp);
         });
       }
     }
@@ -58,11 +63,11 @@ class PropertyList with ChangeNotifier {
 
   List<PropertyItem> get fetchProperties {
     // for app-internal purposes
-    return [..._entries];
+    return [...entries];
   }
 
   PropertyItem findById(String id) {
-    return _entries.firstWhere((property) => property.id == id);
+    return entries.firstWhere((property) => property.id == id);
   }
 
   Future<void> addProperty(newProp) async {
@@ -82,7 +87,7 @@ class PropertyList with ChangeNotifier {
     final id = info["name"]; // extract necessary info (here: DB ID)
     // prive new property with unique ID and add to properties list
     newProp.id = id;
-    _entries.add(newProp);
+    entries.add(newProp);
     notifyListeners();
   }
 }


### PR DESCRIPTION
- `main.dart` : added auth dependency to `PropertyList()` and `CashflowList()` by changing their `ChangeNotifierProvider` to `ChangeNotifierProxyProvider`
    - both lists will be build based on the `auth.token` input --> only authenticated user can retrieve data from DB
    - changes on DB side (not on GH): changed Firebase rules from open to 
    ```
    {
        "rules": {
          ".read": "auth.uid !== null",
          ".write": "auth.uid !== null"
        }
      }
    ```

- `property_list.dart` / `cashflow_list.dart`: 
    - added auth and entries param to class constructors --> to be able to use auth internally + update entry list based auth
    - made `entries` property externally accessible
    - created `authToken` property to pass to data retrieval URL for authentication
    - added authentication info to `http.get` request