### PR TITLE
Improve cashflow details screen

### DIFF
--- a/fix_realxstate/lib/models/cashflowResult.dart
+++ b/fix_realxstate/lib/models/cashflowResult.dart
@@ -181,6 +181,18 @@ class CashflowItem {
     rtiHypo = totalInvestment / (cashflowMonthlyHypo * 12);
   }
 
+// Calculates remaining balance over the years of the term
+// NOTE: interest used needs to be monthly interest (fraction)
+  Map<dynamic, dynamic> calculateAmortization() {
+    Map remainingBalance = {};
+    for (var i = term; i >= 0; i--) {
+      double monthlyInterest = interest / 100 / 12;
+      remainingBalance[(i - term).abs()] = ((mortgage / monthlyInterest) *
+          (1 - 1 / pow((1 + monthlyInterest), (i * 12))));
+    }
+    return remainingBalance;
+  }
+
   void getCashflow() {
     _calculateMortgage(offer, downpayment, interest, term);
     _rentalAssocExpenses();

--- a/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
+++ b/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
@@ -122,17 +122,60 @@ class _CfResultDetailsScreenState extends State<CfResultDetailsScreen> {
                       text1: CF_item.interest.toString(), text2: "%"),
                 ),
                 const Spacer(),
-                CircleAvatarInfo(
-                    text1: CF_item.offer < 10000
-                        ? "\$${(CF_item.offer).toString().split(".")[0]}"
-                        : CF_item.offer < 1000000
-                            ? "\$${(CF_item.offer / 1000).toString()}k"
-                            : "\$${(CF_item.offer / 1000000).toString()}M",
-                    text2: "offer"),
+                TextButton(
+                  onPressed: () => showDialog(
+                    context: context,
+                    builder: (context) => (AlertDialog(
+                      title: Text("Closing Cost"),
+                      content: Text("""
+TOTAL: \$${(CF_item.downpaymentNum + CF_item.bankFees + CF_item.legal + CF_item.homeInsp).toInt().toString()}
+
+Downpayment: \$${CF_item.downpaymentNum.toInt().toString()}
+
+Bank fees: \$${CF_item.bankFees.toInt().toString()}
+
+Legal fees: \$${CF_item.legal.toInt().toString()}
+
+Home Insp. fees: \$${CF_item.homeInsp.toInt().toString()}
+
+                      """),
+                      actions: [
+                        ElevatedButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: Text('Close'))
+                      ],
+                    )),
+                  ),
+                  child: CircleAvatarInfo(
+                      text1: CF_item.offer < 10000
+                          ? "\$${(CF_item.offer).toString().split(".")[0]}"
+                          : CF_item.offer < 1000000
+                              ? "\$${(CF_item.offer / 1000).toString()}k"
+                              : "\$${(CF_item.offer / 1000000).toString()}M",
+                      text2: "offer"),
+                ),
                 const Spacer(),
-                CircleAvatarInfo(
-                    text1: "${CF_item.downpayment.toString()} %",
-                    text2: "down"),
+                TextButton(
+                  onPressed: () => showDialog(
+                    context: context,
+                    builder: (context) => (AlertDialog(
+                      title: Text("Interest"),
+                      content: Text("${CF_item.interest.toString()}% (annual)"),
+                      actions: [
+                        ElevatedButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: Text('Go Back'))
+                      ],
+                    )),
+                  ),
+                  child: CircleAvatarInfo(
+                      text1: "${CF_item.downpayment.toString()} %",
+                      text2: "down"),
+                ),
               ]),
               ListTile(
                 leading: const Icon(Icons.attach_money),

--- a/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
+++ b/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
@@ -161,14 +161,15 @@ Home Insp. fees: \$${CF_item.homeInsp.toInt().toString()}
                   onPressed: () => showDialog(
                     context: context,
                     builder: (context) => (AlertDialog(
-                      title: Text("Interest"),
-                      content: Text("${CF_item.interest.toString()}% (annual)"),
+                      title: Text("Downpayment"),
+                      content: Text(
+                          "\$${CF_item.downpaymentNum.toInt().toString()}"),
                       actions: [
                         ElevatedButton(
                             onPressed: () {
                               Navigator.pop(context);
                             },
-                            child: Text('Go Back'))
+                            child: Text('Close'))
                       ],
                     )),
                   ),

--- a/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
+++ b/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
@@ -10,6 +10,7 @@ import '../providers/cashflow_list.dart';
 import '../models/cashflowResult.dart';
 import '../widgets/cirleAvatarInfo.dart';
 import './cashflowInfo.dart';
+import './cashflowResultsWidgets/mortgageDetailsTemplate.dart';
 
 // called from cashflowResultTile.dart
 class CfResultDetailsScreen extends StatefulWidget {
@@ -90,7 +91,13 @@ class _CfResultDetailsScreenState extends State<CfResultDetailsScreen> {
               Row(children: [
                 TextButton(
                   onPressed: () {
-                    print("CLICKED!!!");
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => MortgageDetailScreen(
+                                CF_item: CF_item,
+                              )),
+                    );
                   },
                   child: CircleAvatarInfo(
                       text1: CF_item.term.toString(), text2: "years"),

--- a/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
+++ b/fix_realxstate/lib/screens/cashflowResultDetails._screen.dart
@@ -103,8 +103,24 @@ class _CfResultDetailsScreenState extends State<CfResultDetailsScreen> {
                       text1: CF_item.term.toString(), text2: "years"),
                 ),
                 const Spacer(),
-                CircleAvatarInfo(
-                    text1: CF_item.interest.toString(), text2: "%"),
+                TextButton(
+                  onPressed: () => showDialog(
+                    context: context,
+                    builder: (context) => (AlertDialog(
+                      title: Text("Interest"),
+                      content: Text("${CF_item.interest.toString()}% (annual)"),
+                      actions: [
+                        ElevatedButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: Text('Go Back'))
+                      ],
+                    )),
+                  ),
+                  child: CircleAvatarInfo(
+                      text1: CF_item.interest.toString(), text2: "%"),
+                ),
                 const Spacer(),
                 CircleAvatarInfo(
                     text1: CF_item.offer < 10000

--- a/fix_realxstate/lib/screens/cashflowResultsWidgets/mortgageDetailsTemplate.dart
+++ b/fix_realxstate/lib/screens/cashflowResultsWidgets/mortgageDetailsTemplate.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../models/cashflowResult.dart';
+import '../../widgets/graphs/simpleLineChart.dart';
+
+class MortgageDetailScreen extends StatelessWidget {
+  // name({Key? key}) : super(key: key);
+  final CashflowItem CF_item;
+  MortgageDetailScreen({required this.CF_item});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Financing Term"),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Flexible(
+                  flex: 1,
+                  child: Text(
+                    "Runtime: ${CF_item.term.toString()} years",
+                    // "${CF_item.id}",
+                    style: TextStyle(fontSize: 17),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Text("!@#"),
+                Container(
+                  child: SimpleLineChart.withSampleData(),
+                  height: 200,
+                  width: 200,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fix_realxstate/lib/screens/cashflowResultsWidgets/mortgageDetailsTemplate.dart
+++ b/fix_realxstate/lib/screens/cashflowResultsWidgets/mortgageDetailsTemplate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
 
 import '../../models/cashflowResult.dart';
 import '../../widgets/graphs/simpleLineChart.dart';
@@ -12,6 +13,19 @@ class MortgageDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    List<MortgageSeries> list = [];
+    CF_item.calculateAmortization().forEach(
+        (key, value) => list.add(MortgageSeries(year: key, sales: value)));
+
+    final charts.Series<MortgageSeries, int> serieslist =
+        charts.Series<MortgageSeries, int>(
+      id: 'Sales',
+      colorFn: (_, __) => charts.MaterialPalette.gray.shadeDefault,
+      domainFn: (MortgageSeries sales, _) => sales.year,
+      measureFn: (MortgageSeries sales, _) => sales.sales,
+      data: list,
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: const Text("Financing Term"),
@@ -36,7 +50,7 @@ class MortgageDetailScreen extends StatelessWidget {
               children: [
                 Text("!@#"),
                 Container(
-                  child: SimpleLineChart.withSampleData(),
+                  child: SimpleLineChart([serieslist], animate: true),
                   height: 200,
                   width: 200,
                 ),

--- a/fix_realxstate/lib/widgets/cirleAvatarInfo.dart
+++ b/fix_realxstate/lib/widgets/cirleAvatarInfo.dart
@@ -34,7 +34,7 @@ class CircleAvatarInfo extends StatelessWidget {
           ),
         ),
       ),
-      maxRadius: MediaQuery.of(context).size.width * 0.1,
+      maxRadius: MediaQuery.of(context).size.width * 0.09,
     );
   }
 }

--- a/fix_realxstate/lib/widgets/graphs/simpleLineChart.dart
+++ b/fix_realxstate/lib/widgets/graphs/simpleLineChart.dart
@@ -46,7 +46,7 @@ class SimpleLineChart extends StatelessWidget {
 /// Sample linear data type.
 class MortgageSeries {
   final int year;
-  final int sales;
+  final double sales;
 
   MortgageSeries({
     required this.year,

--- a/fix_realxstate/lib/widgets/graphs/simpleLineChart.dart
+++ b/fix_realxstate/lib/widgets/graphs/simpleLineChart.dart
@@ -1,0 +1,55 @@
+/// Simple line chart to visualize cashflow data.
+import 'package:charts_flutter/flutter.dart' as charts;
+import 'package:flutter/material.dart';
+
+class SimpleLineChart extends StatelessWidget {
+  final List<charts.Series<dynamic, num>> seriesList;
+  final bool animate;
+
+  SimpleLineChart(this.seriesList, {required this.animate});
+
+  /// Creates a [LineChart] with sample data and no transition.
+  factory SimpleLineChart.withSampleData() {
+    return new SimpleLineChart(
+      _createSampleData(),
+      // Disable animations for image tests.
+      animate: false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return charts.LineChart(seriesList, animate: animate);
+  }
+
+  /// Create one series with sample hard coded data.
+  static List<charts.Series<MortgageSeries, num>> _createSampleData() {
+    final data = [
+      MortgageSeries(year: 0, sales: 5),
+      MortgageSeries(year: 1, sales: 2),
+      MortgageSeries(year: 2, sales: 10),
+      MortgageSeries(year: 3, sales: 7),
+    ];
+
+    return [
+      charts.Series<MortgageSeries, int>(
+        id: 'Sales',
+        colorFn: (_, __) => charts.MaterialPalette.blue.shadeDefault,
+        domainFn: (MortgageSeries sales, _) => sales.year,
+        measureFn: (MortgageSeries sales, _) => sales.sales,
+        data: data,
+      )
+    ];
+  }
+}
+
+/// Sample linear data type.
+class MortgageSeries {
+  final int year;
+  final int sales;
+
+  MortgageSeries({
+    required this.year,
+    required this.sales,
+  });
+}


### PR DESCRIPTION
Made `CircleAvatarInfo` widgets clickable and added relevant information shown on click:

- term avatar: opens new screen with line chart showing amortization over 30 years on click
- interest avatar: opens alert dialog popup with annual interest percentage
- offer avatar: opens alert dialog popup with total closing cost information + information on individual closing cost items 
- downpayment avatar: opens alert dialog popup with downpayment in dollars